### PR TITLE
More support for filters

### DIFF
--- a/grammars/jade.cson
+++ b/grammars/jade.cson
@@ -99,7 +99,7 @@
     ]
   }
   {
-    'begin': '^(\\s*):(markdown)(?=\\(|$)$'
+    'begin': '^(\\s*):(markdown(?:-it)?)(?=\\(|$)'
     'beginCaptures':
       '2':
         'name': 'constant.language.name.markdown.filter.jade'
@@ -110,12 +110,12 @@
         'include': '#filter_args'
       }
       {
-        'include': 'text.html.markdown'
+        'include': 'source.gfm'
       }
     ]
   }
   {
-    'begin': '^(\\s*):(sass)(?=\\(|$)$'
+    'begin': '^(\\s*):(sass)(?=\\(|$)'
     'beginCaptures':
       '2':
         'name': 'constant.language.name.sass.filter.jade'
@@ -131,7 +131,23 @@
     ]
   }
   {
-    'begin': '^(\\s*):(less)(?=\\(|$)$'
+    'begin': '^(\\s*):(scss)(?=\\(|$)'
+    'beginCaptures':
+      '2':
+        'name': 'constant.language.name.scss.filter.jade'
+    'end': '^(?!(\\1\\s)|\\s*$)'
+    'name': 'source.scss.filter.jade'
+    'patterns': [
+      {
+        'include': '#filter_args'
+      }
+      {
+        'include': 'source.css.scss'
+      }
+    ]
+  }
+  {
+    'begin': '^(\\s*):(less)(?=\\(|$)'
     'beginCaptures':
       '2':
         'name': 'constant.language.name.less.filter.jade'
@@ -142,12 +158,12 @@
         'include': '#filter_args'
       }
       {
-        'include': 'source.less'
+        'include': 'source.css.less'
       }
     ]
   }
   {
-    'begin': '^(\\s*):(stylus)(?=\\(|$)$'
+    'begin': '^(\\s*):(stylus)(?=\\(|$)'
     'beginCaptures':
       '2':
         'name': 'constant.language.name.stylus.filter.jade'
@@ -159,6 +175,22 @@
       }
       {
         'include': 'source.stylus'
+      }
+    ]
+  }
+  {
+    'begin': '^(\\s*):(babel)(?=\\(|$)'
+    'beginCaptures':
+      '2':
+        'name': 'constant.language.name.babel.filter.jade'
+    'end': '^(?!(\\1\\s)|\\s*$)'
+    'name': 'source.babel.filter.jade'
+    'patterns': [
+      {
+        'include': '#filter_args'
+      }
+      {
+        'include': 'source.js'
       }
     ]
   }

--- a/grammars/pug.cson
+++ b/grammars/pug.cson
@@ -99,7 +99,7 @@
     ]
   }
   {
-    'begin': '^(\\s*):(markdown)(?=\\(|$)$'
+    'begin': '^(\\s*):(markdown(?:-it)?)(?=\\(|$)'
     'beginCaptures':
       '2':
         'name': 'constant.language.name.markdown.filter.pug'
@@ -110,12 +110,12 @@
         'include': '#filter_args'
       }
       {
-        'include': 'text.html.markdown'
+        'include': 'source.gfm'
       }
     ]
   }
   {
-    'begin': '^(\\s*):(sass)(?=\\(|$)$'
+    'begin': '^(\\s*):(sass)(?=\\(|$)'
     'beginCaptures':
       '2':
         'name': 'constant.language.name.sass.filter.pug'
@@ -131,7 +131,23 @@
     ]
   }
   {
-    'begin': '^(\\s*):(less)(?=\\(|$)$'
+    'begin': '^(\\s*):(scss)(?=\\(|$)'
+    'beginCaptures':
+      '2':
+        'name': 'constant.language.name.scss.filter.pug'
+    'end': '^(?!(\\1\\s)|\\s*$)'
+    'name': 'source.scss.filter.pug'
+    'patterns': [
+      {
+        'include': '#filter_args'
+      }
+      {
+        'include': 'source.css.scss'
+      }
+    ]
+  }
+  {
+    'begin': '^(\\s*):(less)(?=\\(|$)'
     'beginCaptures':
       '2':
         'name': 'constant.language.name.less.filter.pug'
@@ -142,12 +158,12 @@
         'include': '#filter_args'
       }
       {
-        'include': 'source.less'
+        'include': 'source.css.less'
       }
     ]
   }
   {
-    'begin': '^(\\s*):(stylus)(?=\\(|$)$'
+    'begin': '^(\\s*):(stylus)(?=\\(|$)'
     'beginCaptures':
       '2':
         'name': 'constant.language.name.stylus.filter.pug'
@@ -159,6 +175,22 @@
       }
       {
         'include': 'source.stylus'
+      }
+    ]
+  }
+  {
+    'begin': '^(\\s*):(babel)(?=\\(|$)'
+    'beginCaptures':
+      '2':
+        'name': 'constant.language.name.babel.filter.pug'
+    'end': '^(?!(\\1\\s)|\\s*$)'
+    'name': 'source.babel.filter.pug'
+    'patterns': [
+      {
+        'include': '#filter_args'
+      }
+      {
+        'include': 'source.js'
       }
     ]
   }

--- a/grammars/pyjade.cson
+++ b/grammars/pyjade.cson
@@ -100,28 +100,28 @@
     ]
   }
   {
-    'begin': '^(\\s*):(markdown)(?=\\(|$)$'
+    'begin': '^(\\s*):(markdown(?:-it)?)(?=\\(|$)'
     'beginCaptures':
       '2':
-        'name': 'constant.language.name.markdown.filter.jade'
+        'name': 'constant.language.name.markdown.filter.pug'
     'end': '^(?!(\\1\\s)|\\s*$)'
-    'name': 'text.markdown.filter.jade'
+    'name': 'text.markdown.filter.pug'
     'patterns': [
       {
         'include': '#filter_args'
       }
       {
-        'include': 'text.html.markdown'
+        'include': 'source.gfm'
       }
     ]
   }
   {
-    'begin': '^(\\s*):(sass)(?=\\(|$)$'
+    'begin': '^(\\s*):(sass)(?=\\(|$)'
     'beginCaptures':
       '2':
-        'name': 'constant.language.name.sass.filter.jade'
+        'name': 'constant.language.name.sass.filter.pug'
     'end': '^(?!(\\1\\s)|\\s*$)'
-    'name': 'source.sass.filter.jade'
+    'name': 'source.sass.filter.pug'
     'patterns': [
       {
         'include': '#filter_args'
@@ -132,34 +132,66 @@
     ]
   }
   {
-    'begin': '^(\\s*):(less)(?=\\(|$)$'
+    'begin': '^(\\s*):(scss)(?=\\(|$)'
     'beginCaptures':
       '2':
-        'name': 'constant.language.name.less.filter.jade'
+        'name': 'constant.language.name.scss.filter.pug'
     'end': '^(?!(\\1\\s)|\\s*$)'
-    'name': 'source.less.filter.jade'
+    'name': 'source.scss.filter.pug'
     'patterns': [
       {
         'include': '#filter_args'
       }
       {
-        'include': 'source.less'
+        'include': 'source.css.scss'
       }
     ]
   }
   {
-    'begin': '^(\\s*):(stylus)(?=\\(|$)$'
+    'begin': '^(\\s*):(less)(?=\\(|$)'
     'beginCaptures':
       '2':
-        'name': 'constant.language.name.stylus.filter.jade'
+        'name': 'constant.language.name.less.filter.pug'
     'end': '^(?!(\\1\\s)|\\s*$)'
-    'name': 'source.stylus.filter.jade'
+    'name': 'source.less.filter.pug'
+    'patterns': [
+      {
+        'include': '#filter_args'
+      }
+      {
+        'include': 'source.css.less'
+      }
+    ]
+  }
+  {
+    'begin': '^(\\s*):(stylus)(?=\\(|$)'
+    'beginCaptures':
+      '2':
+        'name': 'constant.language.name.stylus.filter.pug'
+    'end': '^(?!(\\1\\s)|\\s*$)'
+    'name': 'source.stylus.filter.pug'
     'patterns': [
       {
         'include': '#filter_args'
       }
       {
         'include': 'source.stylus'
+      }
+    ]
+  }
+  {
+    'begin': '^(\\s*):(babel)(?=\\(|$)'
+    'beginCaptures':
+      '2':
+        'name': 'constant.language.name.babel.filter.pug'
+    'end': '^(?!(\\1\\s)|\\s*$)'
+    'name': 'source.babel.filter.pug'
+    'patterns': [
+      {
+        'include': '#filter_args'
+      }
+      {
+        'include': 'source.js'
       }
     ]
   }

--- a/grammars/pypug.cson
+++ b/grammars/pypug.cson
@@ -100,7 +100,7 @@
     ]
   }
   {
-    'begin': '^(\\s*):(markdown)(?=\\(|$)$'
+    'begin': '^(\\s*):(markdown(?:-it)?)(?=\\(|$)'
     'beginCaptures':
       '2':
         'name': 'constant.language.name.markdown.filter.pug'
@@ -111,12 +111,12 @@
         'include': '#filter_args'
       }
       {
-        'include': 'text.html.markdown'
+        'include': 'source.gfm'
       }
     ]
   }
   {
-    'begin': '^(\\s*):(sass)(?=\\(|$)$'
+    'begin': '^(\\s*):(sass)(?=\\(|$)'
     'beginCaptures':
       '2':
         'name': 'constant.language.name.sass.filter.pug'
@@ -132,7 +132,23 @@
     ]
   }
   {
-    'begin': '^(\\s*):(less)(?=\\(|$)$'
+    'begin': '^(\\s*):(scss)(?=\\(|$)'
+    'beginCaptures':
+      '2':
+        'name': 'constant.language.name.scss.filter.pug'
+    'end': '^(?!(\\1\\s)|\\s*$)'
+    'name': 'source.scss.filter.pug'
+    'patterns': [
+      {
+        'include': '#filter_args'
+      }
+      {
+        'include': 'source.css.scss'
+      }
+    ]
+  }
+  {
+    'begin': '^(\\s*):(less)(?=\\(|$)'
     'beginCaptures':
       '2':
         'name': 'constant.language.name.less.filter.pug'
@@ -143,12 +159,12 @@
         'include': '#filter_args'
       }
       {
-        'include': 'source.less'
+        'include': 'source.css.less'
       }
     ]
   }
   {
-    'begin': '^(\\s*):(stylus)(?=\\(|$)$'
+    'begin': '^(\\s*):(stylus)(?=\\(|$)'
     'beginCaptures':
       '2':
         'name': 'constant.language.name.stylus.filter.pug'
@@ -160,6 +176,22 @@
       }
       {
         'include': 'source.stylus'
+      }
+    ]
+  }
+  {
+    'begin': '^(\\s*):(babel)(?=\\(|$)'
+    'beginCaptures':
+      '2':
+        'name': 'constant.language.name.babel.filter.pug'
+    'end': '^(?!(\\1\\s)|\\s*$)'
+    'name': 'source.babel.filter.pug'
+    'patterns': [
+      {
+        'include': '#filter_args'
+      }
+      {
+        'include': 'source.js'
       }
     ]
   }

--- a/test/test.jade
+++ b/test/test.jade
@@ -252,6 +252,35 @@ html
       block with #[i inline] tag.
 
     | pipe text with #[i inline] tag.
+    
+    //- Filters
+    div
+      :markdown-it
+        - This is *some* _markdown_.
+    
+    script
+      :coffee
+        alert "I knew it!" if elvis?
+    
+    script
+      :babel(presets=['es2015'])
+        const myFunc = () => `This is ES2015 ${ye}.`;
+    
+    style
+      :sass(some-argument)
+        nav
+          ul
+            margin: 0
+    
+    style
+      :less
+        body {
+          div {
+            a {
+              color: red;
+            }
+          }
+        }
 
 
     //- angular with valign

--- a/test/test.pug
+++ b/test/test.pug
@@ -252,6 +252,35 @@ html
       block with #[i inline] tag.
 
     | pipe text with #[i inline] tag.
+    
+    //- Filters
+    div
+      :markdown-it
+        - This is *some* _markdown_.
+    
+    script
+      :coffee
+        alert "I knew it!" if elvis?
+    
+    script
+      :babel(presets=['es2015'])
+        const myFunc = () => `This is ES2015 ${ye}.`;
+    
+    style
+      :sass(some-argument)
+        nav
+          ul
+            margin: 0
+    
+    style
+      :less
+        body {
+          div {
+            a {
+              color: red;
+            }
+          }
+        }
 
 
     //- angular with valign
@@ -292,3 +321,7 @@ html
         var object = {};
     style.
         .test { color: #fff }
+    
+    style
+      :sass()
+        body {background: red;}


### PR DESCRIPTION
This PR does the following grammar changes for [filters](https://pugjs.org/language/filters.html):

- Fix the `begin` regexes for existing filter rules so that bracketed arguments pass as vaild.
- Add support for `babel`, `markdown-it`, and `scss` filters.
- Makes `less` filter properly highlight less syntax.

Before and After screenshots provided:

**Before**
![screenshot from 2017-06-28 08-45-16](https://user-images.githubusercontent.com/2840821/27632673-021f2036-5c2f-11e7-8e48-8d38a1d26050.png)

**After**
![screenshot from 2017-06-28 08-46-35](https://user-images.githubusercontent.com/2840821/27632688-0cd230e0-5c2f-11e7-9199-b94f69d0f3b6.png)